### PR TITLE
This commit fixes the discrepancy between the y$ prefixed bcrypt hash…

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -44,6 +44,7 @@ const rulesConfigPath = path.join(configDir, 'businessRules.dsl'); // Path to th
 const RuleEngineMiddleware = require('./middleware/RuleEngineMiddleware');
 const { authenticateMiddleware, aclMiddleware } = require('./middleware/authenticationMiddleware');
 const Handlebars = require('handlebars');
+const bcrypt = require('bcrypt');
 
 ruleEngine = null; // Global variable to hold the rule engine
 const {  initializeRAG , handleRAG } = require("./modules/ragHandler1");
@@ -552,7 +553,7 @@ function registerRoutes(app, apiConfig) {
                     let isValidPassword = false;
 
                     if (encryption === "bcrypt") {
-                        isValidPassword = await bcrypt.compare(password, user[authentication]);
+                        isValidPassword = await bcrypt.compare(password, transformHash(user[authentication]));
                     } else if (encryption === "sha256") {
                         const hashedPassword = crypto.createHash("sha256").update(password).digest("hex");
                         isValidPassword = hashedPassword === user[authentication];
@@ -1715,7 +1716,12 @@ class Adaptus2Server {
     }
 }
 
-
+function transformHash(hash) {
+    if (hash.startsWith('$2y$')) {
+        return hash.replace(/^\$2y\$/, '$2b$');
+    }
+    return hash;
+}
 
 
 // Export the FlexAPIServer class


### PR DESCRIPTION
This commit fixes the discrepancy between the `$2y$` prefixed bcrypt hashing from Laravel, by replacing it with `$2b$`, which is the way the node bcrypt library handles these hashes. Because they are functionally identical, the hashes remain functionally identical.