### PR TITLE
Business rules reload fix

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1414,7 +1414,9 @@ function buildFilterClause(filterObj, dbTable) {
 function initializeRules() {
     try {
 
-        delete require.cache[require.resolve(rulesConfigPath)];
+        if (require.cache[require.resolve(rulesConfigPath)]) {
+            delete require.cache[require.resolve(rulesConfigPath)];
+        }
         //DSLParser.autoRegisterFromContext(globalContext);
         const dslText = fs.readFileSync(rulesConfigPath, 'utf-8');
         

--- a/src/server.js
+++ b/src/server.js
@@ -1414,8 +1414,8 @@ function buildFilterClause(filterObj, dbTable) {
 function initializeRules() {
     try {
 
+        delete require.cache[require.resolve(rulesConfigPath)];
         //DSLParser.autoRegisterFromContext(globalContext);
-
         const dslText = fs.readFileSync(rulesConfigPath, 'utf-8');
         
         // Use RuleEngine's fromDSL to initialize the engine properly


### PR DESCRIPTION
This adds the condition where we delete the cached file on configReload in the initializeRules() function, if it exists. This allows the configReload to reload business rules on the configReload call.