### PR TITLE
Response module reset data fix

### DIFF
--- a/src/middleware/RuleEngineMiddleware.js
+++ b/src/middleware/RuleEngineMiddleware.js
@@ -31,8 +31,8 @@ class RuleEngineMiddleware {
             const eventType = req.method.toUpperCase(); // HTTP method: "GET", "POST", etc.
             // Normalize the entity name by removing any numeric IDs or UUIDs
             let pathSegments = req.path.split('/').filter(Boolean);
-            // let entityName = pathSegments.includes('api') ? pathSegments[pathSegments.indexOf('api') + 1] : pathSegments[0]; // Ensure we get the correct entity
-            let entityName = req.path.toLowerCase();
+            let entityName = pathSegments.includes('api') ? pathSegments[pathSegments.indexOf('api') + 1] : pathSegments[0]; // Ensure we get the correct entity
+            //let entityName = req.path.toLowerCase();
 
             
             const hasRules = this.ruleEngine.hasRulesForEntity(entityName);

--- a/src/modules/response.js
+++ b/src/modules/response.js
@@ -1,41 +1,44 @@
 /* define a globale response object to store the response from the rule engine
 */
 const response = {
+    success: true,
+    code: null,
     status: 200,
     message: '',
     error: '',
     data: {},
     module: '',
-    setResponse: function(status, message, error, data, module){
-        console.log('Updating response:', { status, message, error, data, module });
-        // if(this.status > status){
-        //     return; // we don't want to override a status code that is already set
-        // }
+    setResponse: function(status, message, error, data, module, success=true, code=null){
+        console.log('Updating response:', { status, message, error, data, module, success, code});
+        this.success = success;
+        this.code = code;
         this.status = status;
         if(status === 600){
             this.status = 200;
         }
         this.message = message;
         this.error = error;
-        this.response = data;
         this.data = data;
         this.module = module;
         return this;
+    },
+    getResponse: function(){
+      return this;
     },
     Reset: function(){
         console.log('Resetting response');
         this.status = 200;
         this.message = '';
-        this.error = '';        
+        this.error = '';
         this.module = '';
-        this.response = "";
+        this.code = null;
+        this.success = true;
+        this.data = {};
         return this;
     },
-    unauthorized: function(){        
+    unauthorized: function(){
         return { httpCode: 403, message: 'Access Denied', code: null };
     },
 }
 
 module.exports = response;
-
-


### PR DESCRIPTION
Modified the response.js module to have the proper data resetting, added the `getResponse()` function to cleanly return the response in the plugins now as well.

Also did a fix in the rule engine middleware, commented out the req.path.toLowercase() and replaced it with the previously commented line `let entityName = pathSegments.includes('api') ? pathSegments[pathSegments.indexOf('api') + 1] : pathSegments[0];` which works.