### PR TITLE
Update authenticationMiddleware.js

### DIFF
--- a/src/middleware/authenticationMiddleware.js
+++ b/src/middleware/authenticationMiddleware.js
@@ -56,8 +56,7 @@ const authenticateToken = async (req, res, next) => {
   if (
     process.env.TOKEN_BLACKLIST_ENABLED &&
     process.env.TOKEN_BLACKLIST_ENABLED.toLowerCase() === 'true' &&
-    process.env.REDIS_URL &&
-    process.env.REDIS_PORT
+    process.env.REDIS_URL
   ) {
     try {
       const client = await getRedisClient();


### PR DESCRIPTION
Removed the REDIS_PORT from the token blacklist logic as it is no longer necessary. Its reference at the top is fine, as blank will be concatenated on top of the full URL. The current implementation in the imports encapsulates both cases of these env vars being present or not, so no change was needed there.