### PR TITLE
Update DynamicRouteHandler.js

### DIFF
--- a/src/modules/DynamicRouteHandler.js
+++ b/src/modules/DynamicRouteHandler.js
@@ -116,10 +116,11 @@ class DynamicRouteHandler {
         const getParamPath = keys && keys.length > 0 ? `/:${keys[0]}?` : "";
         route = `${route}${getParamPath}`;
       }
-   
-  
+
+      // custom error codes for unauthorized (default behavior if not present)
+      const unauthorized = (endpoint.errorCodes && endpoint.errorCodes.unauthorized) ? endpoint.errorCodes.unauthorized : unauthorizedResponse;
       // Create middleware array for the route
-      const middlewares = [aarMiddleware(auth, {acl,unauthorizedResponse }, ruleEngineInstance)];
+      const middlewares = [aarMiddleware(auth, {acl, unauthorized }, ruleEngineInstance)];
       
       // Add rate limiting middleware if configured
       // if (endpoint.rateLimit && endpoint.rateLimit.requestsPerMinute) {


### PR DESCRIPTION
The custom error codes for dynamic endpoints was previously not being passed in. This change allows the previous default behavior to be preserved should it not be passed in by the apiConfig.json endpoint configuration.