### PR TITLE
Fix/swagger docs dynamic endpoint responses

### DIFF
--- a/src/middleware/RuleEngineMiddleware.js
+++ b/src/middleware/RuleEngineMiddleware.js
@@ -5,267 +5,258 @@ const response = require(path.join(__dirname, '../modules/response'));
 const { setContext } = require('../modules/context');
 
 class RuleEngineMiddleware {
-    constructor(rules, dependencyManager) {
-        try {
-            if (!rules) {
-                console.warn('No business rules defined. RuleEngineMiddleware is disabled.');
-                this.ruleEngine = null;
-            } else {
-                this.ruleEngine = rules;
-                this.dependencyManager = dependencyManager;
+  constructor(rules, dependencyManager) {
+    try {
+      if (!rules) {
+        console.warn('No business rules defined. RuleEngineMiddleware is disabled.');
+        this.ruleEngine = null;
+      } else {
+        this.ruleEngine = rules;
+        this.dependencyManager = dependencyManager;
+      }
+    } catch (error) {
+      console.error('Error initializing RuleEngineMiddleware:', error.message);
+      this.ruleEngine = null;
+    }
+  }
+
+  middleware(endpointConfig = null) {
+    const self = this;
+
+    return async (req, res, next) => {
+      // inject request into global context once
+      setContext('req', req);
+
+      if (!self.ruleEngine) {
+        return next();
+      }
+
+      const eventType = req.method.toUpperCase();
+      const pathSegments = req.path.split('/').filter(Boolean);
+      const entityName = pathSegments.includes('api')
+        ? pathSegments[pathSegments.indexOf('api') + 1]
+        : pathSegments[0];
+
+      // === NON-GET (POST/PUT/PATCH/DELETE) ===
+      if (eventType !== 'GET') {
+        if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(eventType) && req.body) {
+          try {
+            // merge context with endpointConfig and dependencyManager.context
+            const ctx = {
+              ...self.dependencyManager.context,
+              endpoint: endpointConfig,
+            };
+
+            // prepare data for rules
+            const data = {
+              ...req.body,
+              user_agent: req.headers['user-agent'],
+              user_ip: req.ip || req.connection?.remoteAddress,
+              method: req.method,
+              path: req.path,
+            };
+
+            await self.ruleEngine.processEvent(
+              eventType,
+              entityName,
+              data,
+              {
+                ...ctx,
+                actions: {
+                  ...(ctx.actions || {}),
+                  update: (ctxInner, _, field, value) => {
+                    req.body[field] = value;
+                  },
+                },
+              }
+            );
+
+            // short-circuit if plugin set response
+            if (
+              (response.data && Object.keys(response.data).length) ||
+              response.error ||
+              response.status !== 200
+            ) {
+              const success = response.success !== undefined
+                ? response.success
+                : (!response.error);
+              return res
+                .status(response.status)
+                .json({
+                  success,
+                  message: response.message,
+                  error: response.error,
+                  data: response.data,
+                  module: response.module,
+                  code: response.code,
+                });
             }
-        } catch (error) {
-            console.error('Error initializing RuleEngineMiddleware:', error.message);
-            this.ruleEngine = null; // Disable middleware if initialization fails
+
+            // handle special 600 status
+            if (response.status === 600) {
+              response.status = 200;
+              return res
+                .status(response.status)
+                .json({
+                  message: response.message,
+                  error: response.error,
+                  data: response.data,
+                  module: response.module,
+                });
+            }
+
+            // reset shared state before continuing
+            response.Reset();
+          } catch (err) {
+            console.error(`Error processing inbound ${eventType} rules:`, err.message);
+            return res
+              .status(500)
+              .json({ error: `${eventType} rules processing failed` });
+          }
         }
-    }
+        return next();
+      }
 
-    middleware() {
-        return async (req, res, next) => {
-            setContext('req', req);
-            if (!this.ruleEngine) {
-                console.warn('RuleEngineMiddleware is disabled. Skipping rules processing.');
-                return next();
-            }
+      // === GET ===
+      const globalContext = self.dependencyManager.context || {};
+      const allRules = self.ruleEngine.getRules();
+      const entityRules = allRules.filter(rule =>
+        rule.resource.toLowerCase() === entityName.toLowerCase() &&
+        rule.event.toUpperCase() === 'GET'
+      );
 
-            const eventType = req.method.toUpperCase(); // HTTP method: "GET", "POST", etc.
-            // Normalize the entity name by removing any numeric IDs or UUIDs
-            let pathSegments = req.path.split('/').filter(Boolean);
-            let entityName = pathSegments.includes('api') ? pathSegments[pathSegments.indexOf('api') + 1] : pathSegments[0]; // Ensure we get the correct entity
-            //let entityName = req.path.toLowerCase();
+      const hasGetIn = entityRules.some(r => r.direction === 'in');
+      const hasGetOut = entityRules.some(r => r.direction === 'out');
+      const hasGenericGet = entityRules.some(r => r.direction == null);
 
+      // --- GET INBOUND ---
+      if (hasGetIn || hasGenericGet) {
+        if (req.query && Object.keys(req.query).length) {
+          try {
+            const data = {
+              ...req.query,
+              user_agent: req.headers['user-agent'],
+              user_ip: req.ip || req.connection?.remoteAddress,
+              method: req.method,
+              path: req.path,
+            };
 
-            const hasRules = this.ruleEngine.hasRulesForEntity(entityName);
-            if (!hasRules) {
-                // console.log(`No rules defined for entity: ${entityName}. Skipping rule processing.`);
-                return next();
-            } else {
-                const globalContext = this.dependencyManager.context; // Access globalContext from DependencyManager
+            await self.ruleEngine.processEvent(
+              'GET',
+              entityName,
+              data,
+              {
+                ...globalContext,
+                endpoint: endpointConfig,
+                req,
+                res,
+                actions: {
+                  ...(globalContext.actions || {}),
+                  update: (_, __, field, value) => {
+                    req.query[field] = value;
+                  },
+                },
+                direction: 'in',
+              }
+            );
+          } catch (err) {
+            console.error('Error processing inbound GET rules:', err.message);
+            return res
+              .status(500)
+              .json({ error: 'GET query parameter processing failed' });
+          }
+        }
+        return next();
+      }
 
-                if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(eventType) && req.body) {
-                    console.log(`Processing inbound ${eventType} on ${entityName} with data:`, req.body);
+      // --- GET OUTBOUND ---
+      if (hasGetOut) {
+        const originalSend = res.send;
+        res.send = async (responseData) => {
+          if (res.statusCode >= 300) {
+            return originalSend.call(res, responseData);
+          }
 
-                    try {
-                        // Only include user_agent and user_ip for rule processing
-                        const data = {
-                            ...req.body,
-                            user_agent: req.headers['user-agent'],
-                            user_ip: req.ip || req.connection.remoteAddress,
-                            method: req.method,
-                            path: req.path
-                        };
+          try {
+            let parsed = typeof responseData === 'string'
+              ? JSON.parse(responseData)
+              : responseData;
 
-                        await this.ruleEngine.processEvent(eventType, entityName, data, {
-                            ...globalContext, // Merge globalContext into the rule processing context
-                            actions: {
-                                ...globalContext.actions, // Use global actions
-                                update: (ctx, entity, field, value) => {
-                                    req.body[field] = value; // Modify request payload
-                                },
-                            },
-                        });
+            // Ensure a data array for rule processing
+            const payload = parsed.data
+              ? (Array.isArray(parsed.data) ? parsed.data : [parsed.data])
+              : [];
 
-                        // *** NEW CHECK START ***
-                        // Check if the plugin modified the shared response state significantly.
-                        // NOTE: Relies on shared state, potential concurrency issues remain, but respects original architecture.
-                        // It checks if data was added, an error was set, or status changed from default 200.
-                        if (
-                            (response.data && Object.keys(response.data).length > 0 && response.module) || // Check if plugin set data AND module name
-                            (response.error && response.error !== '') ||                               // Check if an error string was set
-                            response.status !== 200                                                    // Check if status was changed from default
-                        ) {
-                            // console.log('[DEBUG RuleEngineMiddleware] Plugin appears to have modified the shared response. Sending current shared response state.');
-                            // Send the current state of the shared response object
-                            res.status(response.status).json({
-                                success: response.success !== undefined ? response.success : (response.error ? false : true),
-                                message: response.message,
-                                error: response.error,
-                                data: response.data,
-                                module: response.module,
-                                code: response.code
-                            });
-                        }
-                        // *** NEW CHECK END ***
-
-                        // Existing check for status 600 (seems unrelated, keeping it)
-                        if(response.status === 600){
-                            response.status = 200;
-                            return res.status(response.status).json({ message: response.message, error: response.error, data: response.data, module: response.module });
-                        }
-
-                        // If plugin didn't modify response, proceed as normal
-                        // console.log('[DEBUG RuleEngineMiddleware] Plugin did not significantly modify shared response. Calling next().');
-                        response.Reset(); // Reset shared state before calling next
-                        return next();
-
-                    } catch (err) {
-                        console.error(`Error processing inbound ${eventType} rules:`, err.message);
-                        return res.status(500).json({ error: `${eventType} rules processing failed` });
+            if (payload.length) {
+              // custom update merges back into parsed.data
+              const customUpdate = (ctxInner, action) => {
+                if (!action.field) return;
+                let computed;
+                if (typeof action.expression === 'string') {
+                  computed = action.expression.replace(
+                    /\${([^}]+)}/g,
+                    (_, expr) => {
+                      try {
+                        const fn = new Function('data', `with(data){return ${expr}}`);
+                        return fn(ctxInner.data);
+                      } catch {
+                        return null;
+                      }
                     }
-                } else if (eventType === 'GET') {
-                    // console.log(`Processing ${eventType} request on ${entityName}`);
-                    let inboundProcessed = false;
-
-                    // Process incoming GET query parameters (GETIN)
-                    if (req.query && Object.keys(req.query).length > 0) {
-                        // console.log(`Processing inbound GET (GETIN) query parameters for ${entityName}:`, req.query);
-                        try {
-                            // Only include user_agent and user_ip for rule processing
-                            const data = {
-                                ...req.query,
-                                user_agent: req.headers['user-agent'],
-                                user_ip: req.ip || req.connection.remoteAddress,
-                                method: req.method,
-                                path: req.path
-                            };
-
-                            // Process with direction='in' for GETIN rules
-                            await this.ruleEngine.processEvent(eventType, entityName, data, {
-                                ...globalContext,
-                                actions: {
-                                    ...globalContext.actions,
-                                    update: (ctx, entity, field, value) => {
-                                        req.query[field] = value;
-                                    },
-                                },
-                                direction: 'in'  // Specify 'in' direction for GETIN rules
-                            });
-                            inboundProcessed = true;
-                        } catch (err) {
-                            console.error(`Error processing inbound GET (GETIN) query parameters:`, err.message);
-                            return res.status(500).json({ error: `GET query parameter processing failed` });
-                        }
-                    }
-
-                    // Set up interception of outbound data (GETOUT)
-                    const originalSend = res.send;
-                    res.send = async (responseData) => {
-                        if (res.statusCode >= 300) {
-                            // console.log(`Skipping rule processing because status is ${res.statusCode} for ${entityName}`);
-                            return originalSend.call(res, responseData);
-                        }
-
-                        // console.log(`Processing outbound GET (GETOUT) on ${entityName} with data`);
-                        try {
-                            // Parse response data if it's a string; handle invalid JSON gracefully
-                            let parsedData;
-                            try {
-                                parsedData = typeof responseData === 'string' ? JSON.parse(responseData) : responseData;
-                            } catch (parseError) {
-                                // console.warn(`Failed to parse response data for ${entityName}. Skipping rule processing.`);
-                                return originalSend.call(res, responseData);
-                            }
-
-                            if (!parsedData) {
-                                // console.log(`No valid data available for entity: ${entityName}. Skipping rule processing.`);
-                                return originalSend.call(res, responseData);
-                            }
-
-                            // Ensure parsedData.data exists by wrapping single objects in a `data` field
-                            if (!parsedData.data) {
-                                parsedData = { data: parsedData }; // Wrap the entire response
-                            }
-
-                            // Convert single object responses into an array for rule processing
-                            const ruleData = Array.isArray(parsedData.data) ? parsedData.data : [parsedData.data];
-
-                            // Process with direction='out' for GETOUT rules
-                            //  console.log("Before rule processing, data:", JSON.stringify(ruleData));
-
-                            // Define a custom update action that modifies both ruleData and parsedData
-                            const customUpdateAction = (ctx, action) => {
-                                if (action.field && action.expression) {
-                                    try {
-
-
-                                        // Get the computed value from the expression
-                                        let computedValue;
-                                        if (typeof action.expression === 'string') {
-                                            // Handle string expressions with placeholders
-                                            computedValue = action.expression.replace(/\${([^}]+)}/g, (match, inner) => {
-                                                try {
-                                                    const fn = new Function('data', `with(data) { return ${inner}; }`);
-                                                    const value = fn(ctx.data);
-                                                    return value !== undefined && value !== null ? value : match;
-                                                } catch (e) {
-                                                    // console.warn(`Failed to resolve placeholder ${match}: ${e.message}`);
-                                                    return match;
-                                                }
-                                            });
-                                        } else {
-                                            computedValue = action.expression;
-                                        }
-
-
-
-                                        // Update the data in the context (affects ruleData)
-                                        ctx.data[action.field] = computedValue;
-
-                                        // Also update parsedData directly
-                                        if (Array.isArray(parsedData.data)) {
-                                            // If it's an array, update each item
-                                            parsedData.data.forEach(item => {
-                                                item[action.field] = computedValue;
-                                            });
-                                        } else if (typeof parsedData.data === 'object') {
-                                            // If it's a single object
-                                            parsedData.data[action.field] = computedValue;
-                                        } else {
-                                            // If it's something else, create an object
-                                            parsedData.data = { [action.field]: computedValue };
-                                        }
-
-
-                                    } catch (err) {
-                                        console.error(`Error in custom update action for field "${action.field}":`, err.message);
-                                    }
-                                }
-                            };
-
-                            await this.ruleEngine.processEvent(eventType, entityName, ruleData, {
-                                ...globalContext,
-                                actions: {
-                                    ...globalContext.actions,
-                                    update: customUpdateAction
-                                },
-                                direction: 'out'  // Specify 'out' direction for GETOUT rules
-                            });
-
-
-
-                            // Recursively clean user data from the response
-                            const cleanUserData = (obj) => {
-                                if (!obj || typeof obj !== 'object') return;
-                                if (Array.isArray(obj)) {
-                                    obj.forEach(item => cleanUserData(item));
-                                } else {
-                                    delete obj.user;
-                                    Object.values(obj).forEach(value => cleanUserData(value));
-                                }
-                            };
-                            if (parsedData.data) {
-                                cleanUserData(parsedData.data);
-                            }
-
-                            originalSend.call(res, JSON.stringify(parsedData));
-
-                        } catch (err) {
-                            console.error(`Error processing outbound GET (GETOUT) rules for entity: ${entityName}:`, err.message);
-                            // Fallback to original response if processing fails
-                            originalSend.call(res, responseData);
-                        }
-                    };
-
-                    if (inboundProcessed) {
-                        return next();
-                    }
+                  );
                 } else {
-                    // console.log(`No rule processing required for ${eventType} on ${entityName}`);
+                  computed = action.expression;
                 }
+                ctxInner.data[action.field] = computed;
+                if (Array.isArray(parsed.data)) {
+                  parsed.data.forEach(item => { item[action.field] = computed; });
+                } else if (parsed.data && typeof parsed.data === 'object') {
+                  parsed.data[action.field] = computed;
+                }
+              };
+
+              await self.ruleEngine.processEvent(
+                'GET',
+                entityName,
+                payload,
+                {
+                  ...globalContext,
+                  endpoint: endpointConfig,
+                  actions: {
+                    ...(globalContext.actions || {}),
+                    update: customUpdate,
+                  },
+                  direction: 'out',
+                }
+              );
             }
-            next();
+
+            // sanitize any nested user fields
+            const clean = obj => {
+              if (!obj || typeof obj !== 'object') return;
+              if (Array.isArray(obj)) {
+                obj.forEach(clean);
+              } else {
+                delete obj.user;
+                Object.values(obj).forEach(clean);
+              }
+            };
+            if (parsed.data) clean(parsed.data);
+
+            originalSend.call(res, JSON.stringify(parsed));
+          } catch (err) {
+            console.error(`Error processing outbound GET rules for ${entityName}:`, err.message);
+            originalSend.call(res, responseData);
+          }
         };
-    }
+
+        return next();
+      }
+
+      // no matching rules
+      return next();
+    };
+  }
 }
 
 module.exports = RuleEngineMiddleware;

--- a/src/middleware/aarMiddleware.js
+++ b/src/middleware/aarMiddleware.js
@@ -12,9 +12,10 @@ const { authenticateMiddleware, aclMiddleware } = require('./authenticationMiddl
  * @param {any|null} authConfig - Configuration for authentication; if null, authentication is disabled.
  * @param {any|null} aclConfig - Configuration for ACL; if null, ACL is disabled.
  * @param {object} ruleEngineInstance - An instance of the RuleEngine middleware.
+ * @param {object} endpointConfig - Optional endpoint configuration to pass to plugins.
  * @returns {Array<Function>} An array of middleware functions.
  */
-function aarMiddleware(authConfig, aclConfig, ruleEngineInstance) {
+function aarMiddleware(authConfig, aclConfig, ruleEngineInstance, endpointConfig = null) {
   const middlewares = [];
 
   // Add authentication middleware if authConfig is provided.
@@ -44,13 +45,13 @@ function aarMiddleware(authConfig, aclConfig, ruleEngineInstance) {
     middlewares.push(aclMiddleware(allowedRoles, message));
   }
 
-  // Always include the RuleEngine middleware.
-  middlewares.push(ruleEngineInstance.middleware());
+  // Always include the RuleEngine middleware with endpoint configuration.
+  middlewares.push(ruleEngineInstance.middleware(endpointConfig));
 
   return middlewares;
 }
 
 module.exports = { aarMiddleware };
-/** TO use it we would declare the route as follows app.get(route, aarMiddleware(auth, acl, ruleEngineInstance) 
+/** TO use it we would declare the route as follows app.get(route, aarMiddleware(auth, acl, ruleEngineInstance)
  * Where auth and acl can be null if those values are NOT present, that will disabled the authentication and ACL middleware
 */

--- a/src/modules/generateSwaggerDoc.js
+++ b/src/modules/generateSwaggerDoc.js
@@ -5,8 +5,13 @@ const path = require('path');
  * Generates Swagger documentation from the given API configuration.
  * @param {Array} apiConfig - The API configuration array from apiConfig.json.
  * @param {String} outputFilePath - Path to save the generated Swagger JSON file.
+ * @param {String} businessRulesPath - Optional path to businessRules.dsl file.
+ * @param {String} pluginsPath - Optional path to plugins directory.
  */
-function generateSwaggerDoc(apiConfig, outputFilePath) {
+function generateSwaggerDoc(apiConfig, outputFilePath, businessRulesPath = null, pluginsPath = null) {
+    // Parse business rules if provided
+    const businessRulesMap = businessRulesPath ? parseBusinessRules(businessRulesPath) : null;
+
     const swaggerDoc = {
         openapi: "3.0.0",
         info: {
@@ -55,21 +60,54 @@ function generateSwaggerDoc(apiConfig, outputFilePath) {
     // Generate tags from unique route prefixes
     const tags = new Set();
     apiConfig.forEach(endpoint => {
-        const routePrefix = endpoint.route.split('/')[2]; // Get prefix after /api/
-        if (routePrefix) {
-            tags.add(routePrefix);
+        if (endpoint.route) {
+            const routePrefix = endpoint.route.split('/')[2]; // Get prefix after /api/
+            if (routePrefix) {
+                tags.add(routePrefix);
+            }
         }
     });
     swaggerDoc.tags = Array.from(tags).map(tag => ({
         name: tag,
         description: `Operations related to ${tag}`
     }));
-    
+
     apiConfig.forEach(endpoint => {
-        const { route, allowMethods = ["GET"], allowRead = [], allowWrite = [], columnDefinitions = {}, auth } = endpoint;
-        console.log(`First Endpoint:`,endpoint);
+        const { route, allowMethods = ["GET"], allowRead = [], allowWrite = [], columnDefinitions = {}, auth, routeType } = endpoint;
+
+        // Skip endpoints without a route
+        if (!route) {
+            console.log(`[DEBUG] Skipping endpoint without route:`, endpoint);
+            return;
+        }
+
+        // NEW: Check if this is a dynamic endpoint with business rules
+        console.log(`[DEBUG] Processing endpoint: ${route}, routeType: ${routeType}, method: ${allowMethods[0]}`);
+        console.log(`[DEBUG] Business rules map exists: ${!!businessRulesMap}`);
+        if (businessRulesMap) {
+            const routeKey = `${allowMethods[0]} ${route}`;
+            console.log(`[DEBUG] Looking for route key: "${routeKey}"`);
+            console.log(`[DEBUG] Available business rules:`, Object.keys(businessRulesMap));
+            console.log(`[DEBUG] Found in business rules: ${!!businessRulesMap[routeKey]}`);
+        }
+
+        if (routeType === 'dynamic' && businessRulesMap && businessRulesMap[`${allowMethods[0]} ${route}`]) {
+            console.log(`[DEBUG] ✓ Generating dynamic Swagger for: ${route}`);
+            const dynamicSwagger = generateDynamicEndpointSwagger(endpoint, businessRulesMap, pluginsPath);
+            console.log(`[DEBUG] Dynamic Swagger generated for ${route}:`, JSON.stringify(dynamicSwagger, null, 2));
+            Object.assign(swaggerDoc.paths, dynamicSwagger);
+            console.log(`[DEBUG] After merge, swaggerDoc.paths[${route}]:`, JSON.stringify(swaggerDoc.paths[route], null, 2));
+            console.log(`[DEBUG] Returning early for dynamic endpoint: ${route}`);
+            return; // Skip the existing logic for this endpoint
+        }
+
+        // EXISTING LOGIC CONTINUES UNCHANGED BELOW
+        console.log(`[DEBUG] Using standard Swagger generation for: ${route}`);
+        if (swaggerDoc.paths[route]) {
+            console.log(`[DEBUG] WARNING: Route ${route} already exists in swaggerDoc.paths, overwriting with standard logic`);
+        }
         swaggerDoc.paths[route] = swaggerDoc.paths[route] || {};
-        
+
         // Determine security based on auth type
         const security = [];
         if (auth === "token") {
@@ -426,11 +464,11 @@ function getPropertyType(columnDefinition) {
 
     // Handle enum values if present
     if (columnDefinition.enum || (typeof columnDefinition === 'string' && columnDefinition.startsWith('ENUM'))) {
-        const enumValues = columnDefinition.enum || 
+        const enumValues = columnDefinition.enum ||
             columnDefinition.match(/ENUM\((.*)\)/i)?.[1]
                 ?.split(',')
                 ?.map(val => val.trim().replace(/'/g, ''));
-                
+
         if (enumValues) {
             property.enum = enumValues;
         }
@@ -489,17 +527,17 @@ function getRequiredFields(columnDefinitions, fields) {
     return fields.filter(field => {
         const def = columnDefinitions[field];
         if (!def) return false;
-        
+
         // Check for NOT NULL in SQL definition
         if (typeof def === 'string' && def.toUpperCase().includes('NOT NULL')) {
             return true;
         }
-        
+
         // Check for required flag in object definition
         if (typeof def === 'object' && def.required === true) {
             return true;
         }
-        
+
         return false;
     });
 }
@@ -520,7 +558,7 @@ function generateExample(columnDefinitions, fields) {
         }
 
         const type = typeof def === 'string' ? def.toUpperCase() : def.type;
-        
+
         if (def.example !== undefined) {
             example[field] = def.example;
         } else if (def.enum || type.startsWith('ENUM')) {
@@ -553,7 +591,7 @@ function generateExample(columnDefinitions, fields) {
 function mapSQLTypeToOpenAPIType(sqlType) {
     if (!sqlType) return "string"; // Default to string if type is unknown
     const type = typeof sqlType === 'string' ? sqlType.toUpperCase() : '';
-    
+
     if (type.startsWith("VARCHAR") || type.startsWith("TEXT") || type.startsWith("ENUM")) return "string";
     if (type.startsWith("INT")) return "integer";
     if (type.startsWith("DECIMAL") || type.startsWith("FLOAT") || type.startsWith("DOUBLE")) return "number";
@@ -562,8 +600,755 @@ function mapSQLTypeToOpenAPIType(sqlType) {
     return "string";
 }
 
+/**
+ * Parse businessRules.dsl file to extract route-to-action mappings
+ * @param {String} filePath - Path to businessRules.dsl file
+ * @returns {Object} Mapping of route keys to action info
+ */
+function parseBusinessRules(filePath) {
+    try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        const lines = content.split('\n');
+        const businessRulesMap = {};
+
+        console.log(`[DEBUG] Parsing business rules file with ${lines.length} lines`);
+
+        let currentRule = null;
+
+        lines.forEach((line, index) => {
+            const trimmedLine = line.trim();
+
+            // Skip empty lines and comments
+            if (!trimmedLine || trimmedLine.startsWith('//')) {
+                return;
+            }
+
+            console.log(`[DEBUG] Processing line ${index + 1}: "${trimmedLine}"`);
+
+            // Check if this is an IF statement (start of a rule)
+            const ifMatch = trimmedLine.match(/IF\s+(GET|POST|PUT|DELETE|PATCH)\s+([^\s]+)\s+THEN/);
+            if (ifMatch) {
+                const [, method, route] = ifMatch;
+                // Add /api/ prefix to match the endpoint routes
+                const fullRoute = route.startsWith('/') ? route : `/api/${route}`;
+                const routeKey = `${method} ${fullRoute}`;
+
+                console.log(`[DEBUG] Found IF statement: ${routeKey}`);
+                currentRule = {
+                    method,
+                    route: fullRoute,
+                    action: null,
+                    params: []
+                };
+                return;
+            }
+
+            // If we have a current rule and this line contains an action, parse it
+            if (currentRule && !currentRule.action) {
+                // Match action with optional data parameters
+                // First, try to match the action name
+                const actionNameMatch = trimmedLine.match(/^([a-zA-Z_][a-zA-Z0-9_]*)/);
+                if (actionNameMatch) {
+                    const action = actionNameMatch[1];
+                    currentRule.action = action;
+                    console.log(`[DEBUG] Found action: ${action} for ${currentRule.method} ${currentRule.route}`);
+
+                    // Now extract data parameters if present
+                    let dataParams = null;
+
+                    // Look for "data: { ... }" pattern
+                    const dataMatch = trimmedLine.match(/data:\s*(\{[^}]*\})/);
+                    if (dataMatch) {
+                        dataParams = dataMatch[1];
+                    } else {
+                        // Look for direct object pattern "{ ... }" (not empty)
+                        const directMatch = trimmedLine.match(/\s+(\{[^}]*\})/);
+                        if (directMatch && directMatch[1] !== '{}') {
+                            dataParams = directMatch[1];
+                        }
+                    }
+
+                    // Parse data parameters if present
+                    if (dataParams) {
+                        try {
+                            console.log(`[DEBUG] Parsing data params: ${dataParams}`);
+                            // Extract parameter names from the data object
+                            // Pattern: "paramName": "${data.paramName}"
+                            const paramMatches = dataParams.match(/"([^"]+)":\s*"\$\{data\.([^}]+)\}"/g);
+                            console.log(`[DEBUG] Param matches found:`, paramMatches);
+                            if (paramMatches) {
+                                currentRule.params = paramMatches.map(match => {
+                                    const paramMatch = match.match(/"([^"]+)":\s*"\$\{data\.([^}]+)\}"/);
+                                    console.log(`[DEBUG] Processing match: ${match} -> ${paramMatch ? paramMatch[2] : 'null'}`);
+                                    return paramMatch ? paramMatch[2] : null;
+                                }).filter(Boolean);
+                            }
+                            console.log(`[DEBUG] Parsed params for ${currentRule.method} ${currentRule.route}:`, currentRule.params);
+                        } catch (e) {
+                            console.log(`[DEBUG] Failed to parse data params: ${dataParams}`);
+                        }
+                    }
+
+                    // Store the completed rule
+                    const routeKey = `${currentRule.method} ${currentRule.route}`;
+                    businessRulesMap[routeKey] = { ...currentRule };
+                    console.log(`[DEBUG] Stored business rule: ${routeKey} -> ${action}`);
+
+                    // Reset for next rule
+                    currentRule = null;
+                }
+            }
+        });
+
+        console.log(`[DEBUG] Parsed ${Object.keys(businessRulesMap).length} business rules:`, Object.keys(businessRulesMap));
+        return businessRulesMap;
+    } catch (error) {
+        console.log(`[DEBUG] Error parsing business rules: ${error.message}`);
+        return {};
+    }
+}
+
+/**
+ * Find plugin action and extract function signature and response schemas
+ * @param {String} actionName - Name of the action to find
+ * @param {String} pluginsPath - Path to plugins directory
+ * @returns {Object} Action information including function signature and response schemas
+ */
+function findPluginAction(actionName, pluginsPath) {
+    try {
+        const fs = require('fs');
+        const path = require('path');
+
+        if (!fs.existsSync(pluginsPath)) {
+            console.log(`[DEBUG] Plugins directory not found: ${pluginsPath}`);
+            return null;
+        }
+
+        const pluginFiles = fs.readdirSync(pluginsPath).filter(file => file.endsWith('.js'));
+
+        for (const file of pluginFiles) {
+            const filePath = path.join(pluginsPath, file);
+            const content = fs.readFileSync(filePath, 'utf8');
+
+            // Look for the action registration pattern: registerAction(..., 'actionName', ...)
+            const registerMatch = content.match(new RegExp(`registerAction\\s*\\([^,]+,\\s*['"]${actionName}['"][^)]*\\)`));
+            if (registerMatch) {
+                console.log(`[DEBUG] Found action ${actionName} registered in ${file}`);
+
+                // Look for the actual function that's bound to this action
+                // Pattern: this.actionName.bind(this) or this.actionName
+                const functionMatch = content.match(new RegExp(`this\\.([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\.bind\\(this\\)`));
+                if (functionMatch) {
+                    const actualFunctionName = functionMatch[1];
+                    console.log(`[DEBUG] Action ${actionName} maps to function ${actualFunctionName}`);
+
+                    // Now look for the actual function definition and extract response schemas
+                    const actualFunctionMatch = content.match(new RegExp(`async\\s+${actualFunctionName}\\s*\\([^)]*\\)\\s*=>\\s*\\{([\\s\\S]*?)\\}`));
+                    if (actualFunctionMatch) {
+                        const functionBody = actualFunctionMatch[1];
+                        console.log(`[DEBUG] Found function body for ${actualFunctionName} (length: ${functionBody.length})`);
+                        console.log(`[DEBUG] Function body preview: ${functionBody.substring(0, 200)}...`);
+                        const responseSchemas = extractResponseSchemas(functionBody);
+                        return {
+                            pluginFile: file,
+                            functionBody: functionBody,
+                            hasReturn: functionBody.includes('return'),
+                            hasCreateResponse: functionBody.includes('createSuccessResponse') || functionBody.includes('createErrorResponse'),
+                            responseSchemas: responseSchemas
+                        };
+                    }
+
+                    // Also look for method definition pattern: async functionName(ctx, paramsData) { ... }
+                    // Use a more robust approach to extract the complete function body
+                    const functionStart = content.indexOf(`async ${actualFunctionName}(`);
+                    if (functionStart !== -1) {
+                        // Find the opening brace after the function signature
+                        const braceStart = content.indexOf('{', functionStart);
+                        if (braceStart !== -1) {
+                            // Use brace counting to find the matching closing brace
+                            let braceCount = 1;
+                            let functionEnd = braceStart + 1;
+
+                            while (braceCount > 0 && functionEnd < content.length) {
+                                if (content[functionEnd] === '{') {
+                                    braceCount++;
+                                } else if (content[functionEnd] === '}') {
+                                    braceCount--;
+                                }
+                                functionEnd++;
+                            }
+
+                            if (braceCount === 0) {
+                                const functionBody = content.substring(braceStart + 1, functionEnd - 1);
+                                console.log(`[DEBUG] Found method body for ${actualFunctionName} (length: ${functionBody.length})`);
+                                console.log(`[DEBUG] Method body preview: ${functionBody.substring(0, 200)}...`);
+                                const responseSchemas = extractResponseSchemas(functionBody);
+                                return {
+                                    pluginFile: file,
+                                    functionBody: functionBody,
+                                    hasReturn: functionBody.includes('return'),
+                                    hasCreateResponse: functionBody.includes('createSuccessResponse') || functionBody.includes('createErrorResponse'),
+                                    responseSchemas: responseSchemas
+                                };
+                            }
+                        }
+                    }
+                }
+
+                // If no bind pattern, look for direct function assignment
+                const directMatch = content.match(new RegExp(`async\\s+${actionName}\\s*\\([^)]*\\)\\s*=>\\s*\\{([\\s\\S]*?)\\}`));
+                if (directMatch) {
+                    const functionBody = directMatch[1];
+                    const responseSchemas = extractResponseSchemas(functionBody);
+                    return {
+                        pluginFile: file,
+                        functionBody: functionBody,
+                        hasReturn: functionBody.includes('return'),
+                        hasCreateResponse: functionBody.includes('createSuccessResponse') || functionBody.includes('createErrorResponse'),
+                        responseSchemas: responseSchemas
+                    };
+                }
+            }
+        }
+
+        console.log(`[DEBUG] Action ${actionName} not found in plugins`);
+        return null;
+    } catch (error) {
+        console.log(`[DEBUG] Error finding plugin action: ${error.message}`);
+        return null;
+    }
+}
+
+/**
+ * Extract response schemas from plugin function body
+ * @param {String} functionBody - The function body to analyze
+ * @returns {Object} Extracted response schemas
+ */
+function extractResponseSchemas(functionBody) {
+    const schemas = {
+        success: null,
+        errors: []
+    };
+
+    try {
+        console.log(`[DEBUG] Analyzing function body for response schemas...`);
+
+        // Extract createSuccessResponse calls with better regex
+        const successMatches = functionBody.match(/createSuccessResponse\s*\(\s*[^,]+,\s*([^,]+),\s*[^,]+/g);
+        if (successMatches) {
+            console.log(`[DEBUG] Found ${successMatches.length} createSuccessResponse calls`);
+            successMatches.forEach((match, index) => {
+                console.log(`[DEBUG] Success match ${index + 1}: ${match}`);
+
+                // Extract the responseData parameter (second parameter)
+                const dataMatch = match.match(/createSuccessResponse\s*\(\s*[^,]+,\s*([^,]+),\s*[^,]+/);
+                if (dataMatch) {
+                    const responseDataVar = dataMatch[1].trim();
+                    console.log(`[DEBUG] Found success response data variable: ${responseDataVar}`);
+
+                    // Look for the responseData object definition with more flexible regex
+                    const dataObjectPattern = new RegExp(`${responseDataVar}\\s*=\\s*\\{([\\s\\S]*?)\\}\\s*;?`);
+                    const dataObjectMatch = functionBody.match(dataObjectPattern);
+                    if (dataObjectMatch) {
+                        const objectContent = dataObjectMatch[1];
+                        console.log(`[DEBUG] Found response data object: ${objectContent}`);
+                        schemas.success = parseObjectToSchema(objectContent);
+                    } else {
+                        console.log(`[DEBUG] Could not find object definition for ${responseDataVar}`);
+                    }
+                }
+            });
+        } else {
+            console.log(`[DEBUG] No createSuccessResponse calls found`);
+        }
+
+        // Extract createErrorResponse calls with better regex
+        const errorMatches = functionBody.match(/createErrorResponse\s*\(\s*[^,]+,\s*[^,]+,\s*[^,]+,\s*([^,]+),\s*([^,]+)/g);
+        if (errorMatches) {
+            console.log(`[DEBUG] Found ${errorMatches.length} createErrorResponse calls`);
+            errorMatches.forEach((match, index) => {
+                console.log(`[DEBUG] Error match ${index + 1}: ${match}`);
+
+                const errorMatch = match.match(/createErrorResponse\s*\(\s*[^,]+,\s*[^,]+,\s*[^,]+,\s*([^,]+),\s*([^,]+)/);
+                if (errorMatch) {
+                    const httpCode = errorMatch[1].trim();
+                    const errorCode = errorMatch[2].trim();
+                    console.log(`[DEBUG] Found error response: HTTP ${httpCode}, Code ${errorCode}`);
+
+                    schemas.errors.push({
+                        httpCode: parseInt(httpCode) || 400,
+                        errorCode: errorCode,
+                        description: getErrorDescription(httpCode)
+                    });
+                }
+            });
+        } else {
+            console.log(`[DEBUG] No createErrorResponse calls found`);
+        }
+
+    } catch (error) {
+        console.log(`[DEBUG] Error extracting response schemas: ${error.message}`);
+    }
+
+    return schemas;
+}
+
+/**
+ * Parse object content to OpenAPI schema
+ * @param {String} objectContent - The object content string
+ * @returns {Object} OpenAPI schema
+ */
+function parseObjectToSchema(objectContent) {
+    const schema = {
+        type: "object",
+        properties: {}
+    };
+
+    try {
+        console.log(`[DEBUG] parseObjectToSchema called with: ${objectContent}`);
+
+        // Split by commas and parse each property
+        const properties = objectContent.split(',').map(prop => prop.trim());
+        console.log(`[DEBUG] Split properties:`, properties);
+
+        properties.forEach(prop => {
+            const colonMatch = prop.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.+)$/);
+            if (colonMatch) {
+                const [, propertyName, propertyValue] = colonMatch;
+                console.log(`[DEBUG] Processing property: ${propertyName} = ${propertyValue}`);
+                const propertySchema = inferPropertyType(propertyValue.trim());
+                if (propertySchema) {
+                    schema.properties[propertyName] = propertySchema;
+                    console.log(`[DEBUG] Added property schema for ${propertyName}:`, propertySchema);
+                }
+            } else {
+                console.log(`[DEBUG] Could not parse property: ${prop}`);
+            }
+        });
+
+        console.log(`[DEBUG] Final schema:`, schema);
+    } catch (error) {
+        console.log(`[DEBUG] Error parsing object to schema: ${error.message}`);
+    }
+
+    return schema;
+}
+
+/**
+ * Infer property type from value
+ * @param {String} value - The property value
+ * @returns {Object} OpenAPI property schema
+ */
+function inferPropertyType(value) {
+    // Remove quotes and trim
+    const cleanValue = value.replace(/['"]/g, '').trim();
+
+    if (cleanValue === 'true' || cleanValue === 'false') {
+        return { type: "boolean", example: cleanValue === 'true' };
+    }
+
+    if (!isNaN(cleanValue) && cleanValue !== '') {
+        return { type: "integer", example: parseInt(cleanValue) };
+    }
+
+    // If this looks like a variable reference, do not include example
+    if (!value.includes('"') && !value.includes("'") && (cleanValue.includes('.') || /^[a-z][a-zA-Z0-9_]*$/.test(cleanValue))) {
+        if (cleanValue.includes('@')) {
+            return { type: "string", format: "email" };
+        }
+        if (cleanValue.includes('-') && cleanValue.length > 20) {
+            return { type: "string", format: "date-time" };
+        }
+        return { type: "string" };
+    }
+
+    if (cleanValue.includes('@')) {
+        return { type: "string", format: "email", example: cleanValue };
+    }
+
+    if (cleanValue.includes('-') && cleanValue.length > 20) {
+        return { type: "string", format: "date-time", example: cleanValue };
+    }
+
+    // Default to string
+    return { type: "string", example: cleanValue };
+}
+
+/**
+ * Get error description based on HTTP code
+ * @param {String} httpCode - HTTP status code
+ * @returns {String} Error description
+ */
+function getErrorDescription(httpCode) {
+    const descriptions = {
+        '400': 'Bad request',
+        '401': 'Unauthorized',
+        '403': 'Forbidden',
+        '404': 'Not found',
+        '500': 'Internal server error'
+    };
+    return descriptions[httpCode] || 'Error';
+}
+
+/**
+ * Generate Swagger documentation for dynamic endpoints based on business rules and plugins
+ * @param {Object} endpoint - Endpoint configuration
+ * @param {Object} businessRulesMap - Parsed business rules mapping
+ * @param {String} pluginsPath - Path to plugins directory
+ * @returns {Object} Swagger path object for the dynamic endpoint
+ */
+function generateDynamicEndpointSwagger(endpoint, businessRulesMap, pluginsPath) {
+    const { route, allowMethods = ["GET"], columnDefinitions = {}, auth, allowWrite = [], validation = {} } = endpoint;
+    const method = allowMethods[0];
+    const routeKey = `${method} ${route}`;
+
+    const businessRule = businessRulesMap[routeKey];
+    if (!businessRule) {
+        console.log(`[DEBUG] No business rule found for ${routeKey}`);
+        return {};
+    }
+
+    const actionInfo = findPluginAction(businessRule.action, pluginsPath);
+    if (!actionInfo) {
+        console.log(`[DEBUG] No plugin action found for ${businessRule.action}`);
+        return {};
+    }
+
+    // Determine security based on auth type
+    const security = [];
+    if (auth === "token") {
+        security.push({ tokenAuth: [] });
+    } else if (auth === "bearer") {
+        security.push({ bearerAuth: [] });
+    }
+
+    const routePrefix = route.split('/')[2];
+    const swaggerPath = {};
+
+    if (method === "GET") {
+        swaggerPath[route] = {
+            get: {
+                tags: routePrefix ? [routePrefix] : undefined,
+                operationId: `${businessRule.action}`,
+                summary: `Dynamic endpoint: ${businessRule.action}`,
+                security,
+                responses: {
+                    "200": {
+                        description: "Successful response",
+                        content: {
+                            "application/json": {
+                                schema: {
+                                    type: "object",
+                                    properties: {
+                                        success: { type: "boolean" },
+                                        data: { type: "object" },
+                                        message: { type: "string" }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        description: "Bad request",
+                        content: {
+                            "application/json": {
+                                schema: { $ref: "#/components/schemas/Error" }
+                            }
+                        }
+                    },
+                    "401": {
+                        description: "Unauthorized",
+                        content: {
+                            "application/json": {
+                                schema: { $ref: "#/components/schemas/Error" }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    } else if (method === "POST") {
+        // Generate request body schema from columnDefinitions and allowWrite, or fall back to validation
+        const requestProperties = {};
+        const requiredFields = [];
+
+        // Determine which fields to use for the request body
+        let fieldsToUse = allowWrite;
+        let fieldDefinitions = columnDefinitions;
+
+        // If allowWrite is empty but validation exists, use validation fields
+        if (allowWrite.length === 0 && Object.keys(validation).length > 0) {
+            console.log(`[DEBUG] Using validation fields for ${route} since allowWrite is empty`);
+            fieldsToUse = Object.keys(validation);
+            fieldDefinitions = validation;
+        }
+
+        // Use the determined fields and their definitions
+        fieldsToUse.forEach(field => {
+            const fieldDef = fieldDefinitions[field];
+            if (fieldDef) {
+                // Convert validation definition to OpenAPI property
+                requestProperties[field] = convertValidationToProperty(fieldDef);
+
+                // Check if field is required
+                if (fieldDef.notEmpty || fieldDef.required) {
+                    requiredFields.push(field);
+                }
+            } else {
+                // Default property if not in definitions
+                requestProperties[field] = { type: "string" };
+            }
+        });
+
+        // Generate specific response schemas based on the action
+        const responses = generateSpecificResponses(businessRule.action, route, actionInfo);
+
+        swaggerPath[route] = {
+            post: {
+                tags: routePrefix ? [routePrefix] : undefined,
+                operationId: `${businessRule.action}`,
+                summary: `Dynamic endpoint: ${businessRule.action}`,
+                security,
+                requestBody: {
+                    required: true,
+                    content: {
+                        "application/json": {
+                            schema: {
+                                type: "object",
+                                required: requiredFields,
+                                properties: requestProperties
+                            },
+                            example: generateExampleFromValidation(validation, fieldsToUse)
+                        }
+                    }
+                },
+                responses
+            }
+        };
+    }
+
+    return swaggerPath;
+}
+
+/**
+ * Convert validation definition to OpenAPI property
+ * @param {Object} validationDef - Validation definition from apiConfig
+ * @returns {Object} OpenAPI property definition
+ */
+function convertValidationToProperty(validationDef) {
+    const property = {
+        type: validationDef.type || "string"
+    };
+
+    // Add description if available
+    if (validationDef.description) {
+        property.description = validationDef.description;
+    }
+
+    // Add pattern if available
+    if (validationDef.regex) {
+        property.pattern = validationDef.regex;
+    }
+
+    // Add enum if available
+    if (validationDef.enum) {
+        property.enum = validationDef.enum;
+    }
+
+    // Add format for email
+    if (validationDef.isValidEmail) {
+        property.format = "email";
+    }
+
+    // Add min/max length
+    if (validationDef.minLength !== undefined) {
+        property.minLength = validationDef.minLength;
+    }
+    if (validationDef.maxLength !== undefined) {
+        property.maxLength = validationDef.maxLength;
+    }
+
+    return property;
+}
+
+/**
+ * Generate example from validation definitions
+ * @param {Object} validation - Validation object from apiConfig
+ * @param {Array} fields - Array of field names
+ * @returns {Object} Example object
+ */
+function generateExampleFromValidation(validation, fields) {
+    const example = {};
+    fields.forEach(field => {
+        const fieldDef = validation[field];
+        if (!fieldDef) {
+            example[field] = "";
+            return;
+        }
+
+        // Use example if provided
+        if (fieldDef.example !== undefined) {
+            example[field] = fieldDef.example;
+        }
+        // Use first enum value if available
+        else if (fieldDef.enum && fieldDef.enum.length > 0) {
+            example[field] = fieldDef.enum[0];
+        }
+        // Use type-specific defaults
+        else if (fieldDef.type === "string") {
+            if (fieldDef.isValidEmail) {
+                example[field] = "user@example.com";
+            } else {
+                example[field] = "example";
+            }
+        }
+        else if (fieldDef.type === "integer") {
+            example[field] = 1;
+        }
+        else if (fieldDef.type === "number") {
+            example[field] = 1.0;
+        }
+        else if (fieldDef.type === "boolean") {
+            example[field] = true;
+        }
+        else {
+            example[field] = "example";
+        }
+    });
+    return example;
+}
+
+/**
+ * Generate specific response schemas based on the action type
+ * @param {String} action - The action name
+ * @param {String} route - The route path
+ * @param {Object} actionInfo - The action information including response schemas
+ * @returns {Object} Response schemas
+ */
+function generateSpecificResponses(action, route, actionInfo) {
+    const responses = {};
+
+    console.log(`[DEBUG] generateSpecificResponses called for ${action} on ${route}`);
+    console.log(`[DEBUG] actionInfo:`, actionInfo);
+    console.log(`[DEBUG] actionInfo.responseSchemas:`, actionInfo?.responseSchemas);
+    console.log(`[DEBUG] actionInfo.responseSchemas.success:`, actionInfo?.responseSchemas?.success);
+
+    // Add success response if we have extracted schema
+    if (actionInfo && actionInfo.responseSchemas && actionInfo.responseSchemas.success) {
+        console.log(`[DEBUG] Using intelligently parsed response schema for ${action}`);
+        responses["200"] = {
+            description: "Successful response",
+            content: {
+                "application/json": {
+                    schema: {
+                        type: "object",
+                        properties: {
+                            success: { type: "boolean", example: true },
+                            data: actionInfo.responseSchemas.success,
+                            message: { type: "string", example: "Operation completed successfully" }
+                        }
+                    }
+                }
+            }
+        };
+    } else {
+        console.log(`[DEBUG] Using fallback generic response schema for ${action}`);
+        // Fallback to generic success response
+        responses["200"] = {
+            description: "Successful response",
+            content: {
+                "application/json": {
+                    schema: {
+                        type: "object",
+                        properties: {
+                            success: { type: "boolean" },
+                            data: { type: "object" },
+                            message: { type: "string" }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    // Add specific error responses if we have extracted schemas
+    if (actionInfo && actionInfo.responseSchemas && actionInfo.responseSchemas.errors) {
+        console.log(`[DEBUG] Adding ${actionInfo.responseSchemas.errors.length} specific error responses for ${action}`);
+        actionInfo.responseSchemas.errors.forEach(error => {
+            responses[error.httpCode.toString()] = {
+                description: error.description,
+                content: {
+                    "application/json": {
+                        schema: { $ref: "#/components/schemas/Error" },
+                        example: {
+                            success: false,
+                            message: error.description,
+                            code: error.httpCode
+                        }
+                    }
+                }
+            };
+        });
+    }
+
+    // Add standard error responses as fallbacks
+    if (!responses["400"]) {
+        responses["400"] = {
+            description: "Bad request",
+            content: {
+                "application/json": {
+                    schema: { $ref: "#/components/schemas/Error" },
+                    example: {
+                        success: false,
+                        message: "Invalid request parameters",
+                        code: 400
+                    }
+                }
+            }
+        };
+    }
+
+    if (!responses["401"]) {
+        responses["401"] = {
+            description: "Unauthorized",
+            content: {
+                "application/json": {
+                    schema: { $ref: "#/components/schemas/Error" },
+                    example: {
+                        success: false,
+                        message: "Authentication required",
+                        code: 401
+                    }
+                }
+            }
+        };
+    }
+
+    if (!responses["500"]) {
+        responses["500"] = {
+            description: "Internal server error",
+            content: {
+                "application/json": {
+                    schema: { $ref: "#/components/schemas/Error" },
+                    example: {
+                        success: false,
+                        message: "An unexpected error occurred",
+                        code: 500
+                    }
+                }
+            }
+        };
+    }
+
+    console.log(`[DEBUG] Final responses for ${action}:`, Object.keys(responses));
+    return responses;
+}
+
 // // Example usage:
 // const apiConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, './config/apiConfig.json'), 'utf-8'));
 // generateSwaggerDoc(apiConfig, './swagger.json');
 
-module.exports = generateSwaggerDoc;
+module.exports = {
+    generateSwaggerDoc,
+    inferPropertyType
+};


### PR DESCRIPTION
## Changes

### "Intelligent" Swagger Generation for Dynamic Responses

- Added support for "intelligently" grabbing the response structure for success and errors from the dynamic endpoint plugins directly (if exists).
- This includes Status and response object variable names/types.

##

### Dynamic Endpoint Context Passthrough

Dynamic endpoints currently do not have any access to the endpoint config info. This is a bit of an issue due to the fact that validation from the `apiConfig.json` endpoint objects do not currently handled automatically, due to the custom nature of dynamic endpoints.

This feature aims to extend the capabilities of the dynamic endpoints via endpoint config passthrough via the `ctx` object.

Here's an example of the `endpointConfig` being passed through:

```
endpointConfig is:
{
  routeType: 'dynamic',
  dbType: 'mysql',
  dbConnection: 'MYSQL_1',
  route: '/api/favorite_workout',
  cache: 0,
  allowMethods: [ 'GET', 'POST', 'DELETE' ],
  validation: {
    id: {
      type: 'string',
      regex: '^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}$',
      errorCodes: [Object]
    }
  }
}
```

Now we're able to access the `validation` property, which will give us the option to validate inputs for dynamic endpoint. 